### PR TITLE
Make code blocks easier to read - gray background

### DIFF
--- a/css/gitlab.css
+++ b/css/gitlab.css
@@ -1375,8 +1375,8 @@ pre {
  word-break:break-all;
  word-wrap:break-word;
  color:rgba(0,0,0,0.85);
- background-color:#ffffff;
- border:1px solid #e5e5e5;
+ background-color:#eaeaea;
+ border:1px solid #b7b7b7;
  border-radius:3px
 }
 pre code {


### PR DESCRIPTION
Change the CSS style for `"pre"` code blocks. Use a gray background with dark-gray border:

Old:

```css
pre {
 background-color:#ffffff;
 border:1px solid #e5e5e5;
}
```

New:

```css
pre {
  background-color:#eaeaea;
  border:1px solid #b7b7b7;
}
```

This is closer to the standard GitHub/Bitbucket style, and increases readability, and makes the rendered document look better.

## Preview of Rendered Markdown

![Screenshot CSS change Preview](https://user-images.githubusercontent.com/6191136/65819504-4c12c580-e215-11e9-8236-72ebd4f8c5f2.png)
