### PR TITLE
tab size 4 in code blocks

### DIFF
--- a/css/gitlab.css
+++ b/css/gitlab.css
@@ -867,7 +867,9 @@ pre {
 }
 code,kbd,pre,samp {
  font-family:monospace, monospace;
- font-size:1em
+ font-size:1em;
+ -moz-tab-size: 4;
+ tab-size: 4;
 }
 button,input,optgroup,select,textarea {
  color:inherit;


### PR DESCRIPTION
Tab size 4 in code blocks should be default for anything deeming itself useful. I don't know, why -moz-tab-size is needed here, though. It this extension running in some kind of legacy mode?